### PR TITLE
Add draft of PBSCluster

### DIFF
--- a/pangeo/__init__.py
+++ b/pangeo/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa
+from .pbs import PBSCluster

--- a/pangeo/pbs.py
+++ b/pangeo/pbs.py
@@ -1,0 +1,163 @@
+from contextlib import contextmanager
+import logging
+import os
+import socket
+import subprocess
+import sys
+
+from distributed import LocalCluster
+from distributed.utils import tmpfile, get_ip_interface
+
+template = """
+#!/bin/bash
+#PBS -N %(name)s
+#PBS -q %(queue)s
+#PBS -A %(project)s
+#PBS -l select=1:ncpus=%(threads_per_worker)d:mpiprocs=1:ompthreads=1
+#PBS -l walltime=%(walltime)s
+#PBS -j oe
+#PBS -m abe
+
+%(base_path)s/dask-worker %(scheduler)s --nthreads %(threads_per_worker)d --memory-limit %(memory)s --name $PBS_JOBNAME-$PBS_JOBID-$PBS_TASKNUM %(extra)s
+"""
+
+
+logger = logging.getLogger(__name__)
+
+
+dirname = os.path.dirname(sys.executable)
+
+
+class PBSCluster(object):
+    """ Launch Dask on a PBS cluster
+
+    Examples
+    --------
+    >>> from pangeo import PBSCluster
+    >>> cluster = PBSCluster(project='...')
+    >>> cluster.start_workers(10)  # this may take a few seconds to launch
+
+    >>> from dask.distributed import Client
+    >>> client = Client(cluster)
+
+    This also works with adaptive clusters.  This automatically launches and
+    kill workers based on load.
+
+    >>> from distributed.deploy import Adaptive
+    >>> adapt = Adaptive(cluster.cluster.scheduler, cluster)
+    """
+    def __init__(self,
+                 name='dask',
+                 q='regular',
+                 project='UCLB0022',  # is there an environment variable I can use?
+                 threads_per_worker=6,
+                 memory='7GB',
+                 walltime='00:30:00',
+                 interface=None,
+                 extra='',
+                 scheduler_file=os.path.expanduser('~/scheduler.json'),
+                 **kwargs):
+        if interface:
+            host = get_ip_interface(interface)
+            extra += '--interface ' + interface
+        else:
+            host = socket.gethostname()
+        self.cluster = LocalCluster(n_workers=0, ip=host, **kwargs)
+        self.config = {'name': name,
+                       'queue': q,
+                       'project': project,
+                       'threads_per_worker': threads_per_worker,
+                       'walltime': walltime,
+                       'scheduler': self.cluster.scheduler.address,
+                       'base_path': dirname,
+                       'memory': memory.replace(' ', ''),
+                       'extra': extra}
+        self.jobs = set()
+
+    def job_script(self):
+        return template % self.config
+
+    @contextmanager
+    def job_file(self):
+        """ Write job submission script to temporary file """
+        with tmpfile(extension='sh') as fn:
+            with open(fn, 'w') as f:
+                f.write(self.job_script())
+
+            yield fn
+
+    def start_workers(self, n=1):
+        """ Start workers and point them to our local scheduler """
+        with self.job_script() as fn:
+            outs = self._calls([['qsub', fn]] * n)
+            jobs = [out.decode().split('.')[0] for out in outs]
+        self.jobs.update(jobs)
+        return jobs
+
+    @property
+    def scheduler_address(self):
+        return self.cluster.scheduler_address
+
+    def _calls(self, cmds):
+        """ Call a command using subprocess.communicate
+
+        This centralzies calls out to the command line, providing consistent
+        outputs, logging, and an opportunity to go asynchronous in the future
+
+        Parameters
+        ----------
+        cmd: List(List(str))
+            A list of commands, each of which is a list of strings to hand to
+            subprocess.communicate
+
+        Examples
+        --------
+        >>> self._calls([['ls'], ['ls', '/foo']])
+
+        Returns
+        -------
+        The stdout result as a string
+        Also logs any stderr information
+        """
+        logger.debug("Submitting the following calls to command line")
+        for cmd in cmds:
+            logger.debug(' '.join(cmd))
+        procs = [subprocess.Popen(cmd,
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.PIPE)
+                 for cmd in cmds]
+
+        result = []
+        for proc in procs:
+            out, err = proc.communicate()
+            if err:
+                logger.error(err.decode())
+            result.append(out)
+        return result
+
+    def _call(self, cmd):
+        """ Singular version of _calls """
+        return self._calls([cmd])[0]
+
+    def stop_workers(self, jobs):
+        if not jobs:
+            return
+        self._call(['qdel'] + list(jobs))
+        self.jobs -= set(jobs)
+
+    def scale_up(self, n, **kwargs):
+        return self.start_workers(n - len(self.jobs))
+
+    def scale_down(self, workers):
+        pass
+        # needs https://github.com/dask/distributed/pull/1659
+        # names = [self.cluster.scheduler.worker_info[w]['name'] for w in workers]
+        # job_ids = {name.split('-')[-2] for name in names}
+        # self.stop_workers(job_ids)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.stop_workers(self.jobs)
+        self.cluster.__exit__(type, value, traceback)

--- a/pangeo/tests/test_pbs.py
+++ b/pangeo/tests/test_pbs.py
@@ -1,0 +1,47 @@
+from time import time, sleep
+
+from dask.distributed import Client
+from distributed.deploy.adaptive import Adaptive
+from distributed.utils_test import loop
+from pangeo import PBSCluster
+
+
+def test_basic(loop):
+    with PBSCluster(walltime='00:02:00', threads_per_worker=2, memory='2 GB',
+                    interface='ib0', loop=loop) as cluster:
+        with Client(cluster) as client:
+            workers = cluster.start_workers(2)
+            future = client.submit(lambda x: x + 1, 10)
+            assert future.result() == 11
+            assert cluster.jobs
+
+            info = client.scheduler_info()
+            w = list(info['workers'].values())[0]
+            assert w['memory_limit'] == 2e9
+            assert w['ncores'] == 2
+
+            cluster.stop_workers(workers)
+
+            start = time()
+            while len(client.scheduler_info()['workers']) > 0:
+                sleep(0.100)
+                assert time() < start + 10
+
+            assert not cluster.jobs
+
+
+def test_adaptive(loop):
+    with PBSCluster(walltime='00:02:00', loop=loop) as cluster:
+        adapt = Adaptive(cluster.cluster.scheduler, cluster, startup_cost=5)
+        with Client(cluster) as client:
+            future = client.submit(lambda x: x + 1, 10)
+            assert future.result() == 11
+
+            assert cluster.jobs
+
+            del future
+
+            start = time()
+            while len(client.scheduler_info()['workers']) > 0:
+                sleep(0.100)
+                assert time() < start + 10

--- a/pangeo/tests/test_pbs.py
+++ b/pangeo/tests/test_pbs.py
@@ -35,8 +35,7 @@ def test_basic(loop):
 
 def test_adaptive(loop):
     with PBSCluster(walltime='00:02:00', loop=loop) as cluster:
-        adapt = Adaptive(cluster.cluster.scheduler, cluster, startup_cost=5,
-                         key=lambda ws: ws.host)
+        cluster.adapt()
         with Client(cluster) as client:
             future = client.submit(lambda x: x + 1, 10)
             assert future.result(60) == 11

--- a/pangeo/tests/test_pbs.py
+++ b/pangeo/tests/test_pbs.py
@@ -7,7 +7,7 @@ from pangeo import PBSCluster
 
 
 def test_basic(loop):
-    with PBSCluster(walltime='00:02:00', threads_per_worker=2, memory='2 GB',
+    with PBSCluster(walltime='00:02:00', threads_per_worker=2, memory='7e9',
                     interface='ib0', loop=loop) as cluster:
         with Client(cluster) as client:
             workers = cluster.start_workers(2)
@@ -17,7 +17,7 @@ def test_basic(loop):
 
             info = client.scheduler_info()
             w = list(info['workers'].values())[0]
-            assert w['memory_limit'] == 2e9
+            assert w['memory_limit'] == 7e9
             assert w['ncores'] == 2
 
             cluster.stop_workers(workers)

--- a/pangeo/tests/test_pbs.py
+++ b/pangeo/tests/test_pbs.py
@@ -1,3 +1,4 @@
+import os
 from time import time, sleep
 
 import pytest
@@ -49,6 +50,7 @@ def test_adaptive(loop):
                 assert time() < start + 10
 
 
+@pytest.mark.skipif('PBS_ACCOUNT' in os.environ, reason='PBS_ACCOUNT defined')
 def test_errors(loop):
     with pytest.raises(ValueError) as info:
         PBSCluster()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,39 @@
+[flake8]
+# References:
+# https://flake8.readthedocs.io/en/latest/user/configuration.html
+# https://flake8.readthedocs.io/en/latest/user/error-codes.html
+
+# Note: there cannot be spaces after comma's here
+exclude = __init__.py
+ignore =
+    # Extra space in brackets
+    E20,
+    # Multiple spaces around ","
+    E231,E241,
+    # Comments
+    E26,
+    # Import formatting
+    E4,
+    # Comparing types instead of isinstance
+    E721,
+    # Assigning lambda expression
+    E731,
+    # Ambiguous variable names
+    E741
+max-line-length = 120
+
+[versioneer]
+VCS = git
+style = pep440
+versionfile_source = dask/_version.py
+versionfile_build = dask/_version.py
+tag_prefix =
+parentdir_prefix = dask-
+
+[aliases]
+test = pytest
+
+[tool:pytest]
+markers:
+  skip_if_np_ge_114: Skip a test when NumPy is older than 1.14
+  skip_if_np_lt_114: Skip a test when NumPy is at least 1.14

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import toolz
 setup(name='pangeo',
       version='0.0.1',
       description='',
-      url=''
+      url='',
       license='BSD',
       packages=['pangeo'],
       long_description=(open('README.md').read() if exists('README.md') else ''),

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+from os.path import exists
+from setuptools import setup
+import toolz
+
+setup(name='pangeo',
+      version='0.0.1',
+      description='',
+      url=''
+      license='BSD',
+      packages=['pangeo'],
+      long_description=(open('README.md').read() if exists('README.md') else ''),
+      zip_safe=False)


### PR DESCRIPTION
This provides a Pythonic way to launch Dask clusters on a PBS cluster
from Python.

This also works with adaptive clusters

Examples
--------

```python
>>> from pangeo import PBSCluster
>>> cluster = PBSCluster(project='...')
>>> cluster.start_workers(10)  # this may take a few seconds to launch

>>> from dask.distributed import Client
>>> client = Client(cluster)

This also works with adaptive clusters.  This automatically launches and
kill workers based on load.

>>> cluster.adapt()
```