### PR TITLE
en_US.utf8 for slurm job template

### DIFF
--- a/pangeo/slurm.py
+++ b/pangeo/slurm.py
@@ -79,6 +79,10 @@ class SLURMCluster(JobQueue):
 #SBATCH -e %(name)s.err
 #SBATCH -o %(name)s.out
 
+export LANG="en_US.utf8"
+export LANGUAGE="en_US.utf8"
+export LC_ALL="en_US.utf8"
+
 %(base_path)s/dask-worker %(scheduler)s \
     --nthreads %(threads_per_worker)d \
     --nprocs %(processes)s \


### PR DESCRIPTION
I have been finding that this is necessary on Geyser. @jedwards4b or @davidedelvento may know a better way to make sure these environment variables are set but `click` doesn't seem to like the barebones environment.