### PR TITLE
easier customization of conda env/module

### DIFF
--- a/utilities/habanero/launch-dask-scheduler.sh
+++ b/utilities/habanero/launch-dask-scheduler.sh
@@ -11,8 +11,7 @@
 # >>> client = Client(scheduler_file='~/scheduler.json')
 
 # Setup Environment
-module load anaconda
-source activate pangeo
+source mod_env_setup.sh
 
 LDIR=/local/$USER
 rm -rf $LDIR

--- a/utilities/habanero/launch-dask-worker.sh
+++ b/utilities/habanero/launch-dask-worker.sh
@@ -11,8 +11,7 @@
 # >>> client = Client(scheduler_file='~/scheduler.json')
 
 # Setup Environment
-module load anaconda
-source activate pangeo
+source mod_env_setup.sh
 
 # memory-limit is per process
 # since we use six processes, we request approx 1/6 of system memory

--- a/utilities/habanero/launch-dask.sh
+++ b/utilities/habanero/launch-dask.sh
@@ -32,7 +32,6 @@ default=$HOME
 notebook=${2:-$default}
 echo "Setting up Jupyter Lab, Notebook dir: ${notebook}"
 
-module load anaconda
-source activate pangeo
+source mod_env_setup.sh
 ./setup-jlab.py --log_level=DEBUG --jlab_port=8877 --dash_port=8878 \
     --notebook_dir $notebook --scheduler_file $HOME/scheduler.json

--- a/utilities/habanero/mod_env_setup.sh
+++ b/utilities/habanero/mod_env_setup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-load module anaconda
+module load anaconda
 source activate pangeo

--- a/utilities/habanero/mod_env_setup.sh
+++ b/utilities/habanero/mod_env_setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+load module anaconda
+source activate pangeo

--- a/utilities/habanero/setup-jlab.py
+++ b/utilities/habanero/setup-jlab.py
@@ -78,11 +78,10 @@ def cli(scheduler_file, jlab_port, dash_port, notebook_dir,
 
     user = os.environ['USER']
     print('Run the following command from your local machine:')
-    print(f'ssh -N -L {jlab_port}:{host}:{jlab_port} '
-          f'-L {dash_port}:{host}:8787 {user}@{hostname}')
+    print('ssh -N -L {}:{}:{} -L {}:{}:8787 {}@{}'.format(jlab_port, host, jlab_port, dash_port, host, user, hostname))
     print('Then open the following URLs:')
-    print(f'\tJupyter lab: http://localhost:{jlab_port}')
-    print(f'\tDask dashboard: http://localhost:{dash_port}', flush=True)
+    print('\tJupyter lab: http://localhost:{}'.format(jlab_port))
+    print('\tDask dashboard: http://localhost:{}'.format(dash_port))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR implements: 

1) A single script to load necessary modules and conda environments (which gets sourced in all other scripts). This makes it much easier to customize these variables (I run a local conda install with a different name)

2) Improve compatibility issue with python < 3.6  in setup_jlab.py (f string formatting produces an error)

