### PR TITLE
Use a weighted mean for the sealevel example

### DIFF
--- a/gce/notebook/examples/sea-surface-height.ipynb
+++ b/gce/notebook/examples/sea-surface-height.ipynb
@@ -46,7 +46,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gcsmap = gcsfs.mapping.GCSMap('pangeo-data/dataset-duacs-rep-global-merged-allsat-phy-l4-v3-alt')\n",
+    "gcsmap = gcsfs.mapping.GCSMap(\n",
+    "    'pangeo-data/dataset-duacs-rep-global-merged-allsat-phy-l4-v3-alt')\n",
     "ds = xr.open_zarr(gcsmap)\n",
     "ds"
    ]
@@ -85,8 +86,16 @@
    "source": [
     "from dask.distributed import Client, progress\n",
     "\n",
-    "from dask_kubernetes import KubeCluster\n",
-    "cluster = KubeCluster(n_workers=20)\n",
+    "from dask_kubernetes import KubeCluster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster = KubeCluster(n_workers=20, silence_logs=50)\n",
     "cluster"
    ]
   },
@@ -123,7 +132,7 @@
    "outputs": [],
    "source": [
     "plt.rcParams['figure.figsize'] = (15, 8)\n",
-    "ds.sla.sel(time='1982-08-07', method='nearest').plot()"
+    "ds.sla.sel(time='1982-08-07', method='nearest').plot();"
    ]
   },
   {
@@ -141,8 +150,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# the number of GB involved in the reduction\n",
-    "ds.sla.nbytes/1e9"
+    "# the number of GiB involved in the reduction\n",
+    "ds.sla.nbytes / 1e9"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def _coslat_weighted_mean(da):\n",
+    "    lat = da.coords['latitude']\n",
+    "    \n",
+    "    # construct a masked 3d cosine of the latitude\n",
+    "    coslat = xr.ufuncs.cos(xr.ufuncs.deg2rad(lat)).where(da)\n",
+    "    \n",
+    "    # weights are coslat / global sum\n",
+    "    weights = coslat / coslat.sum(dim=('latitude', 'longitude'))\n",
+    "\n",
+    "    return (da * weights).sum(dim=('latitude', 'longitude'))"
    ]
   },
   {
@@ -152,7 +179,7 @@
    "outputs": [],
    "source": [
     "# the computationally intensive step\n",
-    "sla_timeseries = ds.sla.mean(dim=('latitude', 'longitude')).load()"
+    "sla_timeseries = _coslat_weighted_mean(ds.sla).load()"
    ]
   },
   {
@@ -164,7 +191,7 @@
     "sla_timeseries.plot(label='full data')\n",
     "sla_timeseries.rolling(time=365, center=True).mean().plot(label='rolling annual mean')\n",
     "plt.legend()\n",
-    "plt.grid()"
+    "plt.grid();"
    ]
   },
   {
@@ -190,7 +217,7 @@
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots(figsize=(12,4))\n",
-    "sla_hov.transpose().plot(vmax=0.2, ax=ax)"
+    "sla_hov.transpose().plot(vmax=0.2, ax=ax);"
    ]
   },
   {
@@ -224,15 +251,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sla_std.plot()"
+    "sla_std.plot();"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
With a lot of the signal from high latitudes, not accounting for the cosine of the latitude will overestimate the increase:

![sla_diff](https://user-images.githubusercontent.com/5700886/38720930-67e83e8c-3ef8-11e8-9eae-74d1d53809b6.png)

Weighting adds some complexity to the example.  So I'm not sure if this PR really helps with the notebook being a nice and instructive demo...  On the other hand it nicely shows that Dask also handles arithmetics beyond the more obvious reductions.