### PR TITLE
Fix templates breaking after 0.7.0 upgrade

### DIFF
--- a/gce/jupyter-config.yaml
+++ b/gce/jupyter-config.yaml
@@ -34,19 +34,19 @@ jupyterhub:
             )
             return pod
         c.KubeSpawner.modify_pod_hook = modify_pod_hook
-        c.JupyterHub.logo_file = '/usr/local/share/jupyter/hub/static/custom/images/logo.png'
-        c.JupyterHub.template_paths = ['/usr/local/share/jupyter/hub/custom_templates/',
-                                      '/usr/local/share/jupyter/hub/templates/']
+        c.JupyterHub.logo_file = '/usr/local/share/jupyterhub/static/custom/images/logo.png'
+        c.JupyterHub.template_paths = ['/usr/local/share/jupyterhub/custom_templates/',
+                                      '/usr/local/share/jupyterhub/templates/']
     extraVolumes:
       - name: custom-templates
         gitRepo:
           repository: "https://github.com/pangeo-data/pangeo-custom-jupyterhub-templates.git"
           revision: "b09721bb1a1248dc115730d3c8a791600eae257e"
     extraVolumeMounts:
-      - mountPath: /usr/local/share/jupyter/hub/custom_templates
+      - mountPath: /usr/local/share/jupyterhub/custom_templates
         name: custom-templates
         subPath: "pangeo-custom-jupyterhub-templates/templates"
-      - mountPath: /usr/local/share/jupyter/hub/static/custom
+      - mountPath: /usr/local/share/jupyterhub/static/custom
         name: custom-templates
         subPath: "pangeo-custom-jupyterhub-templates/assets"
 


### PR DESCRIPTION
Jupyterhub after 0.7.0 looks in `/usr/local/share/jupyterhub/` not `/usr/local/share/jupyter/hub/` for static content. Moving this path makes the images display again.