### PR TITLE
Generate documentation table from intake catalog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,17 @@ addons:
   apt_packages:
     - pandoc
 install: pip install -r docs/requirements.txt
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+  - conda create -q -n docs-environment -c conda-forge -c intake python=$TRAVIS_PYTHON_VERSION intake intake-xarray
+  - source activate docs-environment
+  - pip install -r docs/requirements.txt
 
 # https://github.com/drdoctr/doctr
 sudo: false

--- a/docs/_static/pangeo-style.css
+++ b/docs/_static/pangeo-style.css
@@ -120,3 +120,11 @@ h3 {
 .icon {
   color: #003B71;
 }
+
+/* Data catalog */
+.data-catalog .list-inline {
+    margin-bottom: 0px;
+}
+.data-catalog pre {
+    margin-bottom: 0px;
+}

--- a/docs/catalog.rst
+++ b/docs/catalog.rst
@@ -1,0 +1,33 @@
+.. _catalog:
+
+Pangeo Data Catalog
+===================
+
+These datasets are directly accessible from the Google Cloud Pangeo deployment:
+`pangeo.pydata.org <http://pangeo.pydata.org>`_.
+
+.. raw:: html
+
+    <table class="data-catalog table table-striped large">
+    {% for name in catalog.walk() %}
+      {% set entry = catalog[name] %}
+
+      <tr>
+        <td>
+          <ul class="list-inline">
+            <li><strong>{{ name }}</strong></li><br>
+            <li>{{ entry.description }}</li><br>
+            <li><em>Format: {{ entry.describe_open()['plugin'] }}</em></li>
+            <li><em>Container: {{ entry.container }}</em></li><br>
+            <li><em>Location: {{ entry.urlpath }}</em></li>
+            <li>
+            <pre>import intake
+    catalog_url = 'https://github.com/pangeo-data/pangeo/raw/master/gce/catalog.yaml'
+    {{ name }} = intake.Catalog(catalog_url).{{ name }}.to_dask()</pre>
+            </li>
+          </ul>
+        </td>
+      </tr>
+    {% endfor %}
+    </table>
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -273,6 +273,8 @@ def setup(app):
     app.add_stylesheet("example_gallery_styles_patched.css")
     app.connect("source-read", rstjinja)
 
+import intake
+catalog = intake.Catalog('../gce/catalog.yaml')
 
 # a hack to get our custom people data into sphinx
 import yaml
@@ -285,5 +287,6 @@ with open('data/deployments.yml') as deployments_data_file:
 
 html_context = {
     'people': people,
-    'deployments': deployments
+    'deployments': deployments,
+    'catalog': catalog
 }

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -100,30 +100,7 @@ datasets.
 These datasets are directly accessible from the Google Cloud Pangeo deployment:
 `pangeo.pydata.org <http://pangeo.pydata.org>`_.
 
-.. raw:: html
-
-    <table class="data-catalog table table-striped large">
-    {% for name in catalog.walk() %}
-      {% set entry = catalog[name] %}
-
-      <tr>
-        <td>
-          <ul class="list-inline">
-            <li><strong>{{ name }}</strong></li><br>
-            <li>{{ entry.description }}</li><br>
-            <li><em>Format: {{ entry.describe_open()['plugin'] }}</em></li>
-            <li><em>Container: {{ entry.container }}</em></li><br>
-            <li><em>Location: {{ entry.urlpath }}</em></li>
-            <li>
-            <pre>import intake
-    catalog_url = 'https://github.com/pangeo-data/pangeo/raw/master/gce/catalog.yaml'
-    {{ name }} = intake.Catalog(catalog_url).{{ name }}.to_dask()</pre>
-            </li>
-          </ul>
-        </td>
-      </tr>
-    {% endfor %}
-    </table>
+See the list of available data sets in the :ref:`data catalog <catalog>`.
 
 .. _cloud-data-guide:
 

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -100,12 +100,25 @@ datasets.
 These datasets are directly accessible from the Google Cloud Pangeo deployment:
 `pangeo.pydata.org <http://pangeo.pydata.org>`_.
 
-+--------+--------------+
-| Name   | Description  |
-+========+==============+
-| Under  | Construction |
-+--------+--------------+
+.. raw:: html
 
+    <table class="table table-striped large">
+    {% for name in catalog.walk() %}
+      {% set entry = catalog[name] %}
+
+      <tr>
+        <td>
+          <ul class="list-inline">
+            <li><strong>{{ name }}</strong></li><br>
+            <li>{{ entry.description }}</li><br>
+            <li><em>Format: {{ entry.describe_open()['plugin'] }}</em></li>
+            <li><em>Container: {{ entry.container }}</em></li><br>
+            <li><em>Location: {{ entry.urlpath }}</em></li>
+          </ul>
+        </td>
+      </tr>
+    {% endfor %}
+    </table>
 
 .. _cloud-data-guide:
 

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -102,7 +102,7 @@ These datasets are directly accessible from the Google Cloud Pangeo deployment:
 
 .. raw:: html
 
-    <table class="table table-striped large">
+    <table class="data-catalog table table-striped large">
     {% for name in catalog.walk() %}
       {% set entry = catalog[name] %}
 
@@ -114,6 +114,11 @@ These datasets are directly accessible from the Google Cloud Pangeo deployment:
             <li><em>Format: {{ entry.describe_open()['plugin'] }}</em></li>
             <li><em>Container: {{ entry.container }}</em></li><br>
             <li><em>Location: {{ entry.urlpath }}</em></li>
+            <li>
+            <pre>import intake
+    catalog_url = 'https://github.com/pangeo-data/pangeo/raw/master/gce/catalog.yaml'
+    {{ name }} = intake.Catalog(catalog_url).{{ name }}.to_dask()</pre>
+            </li>
           </ul>
         </td>
       </tr>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,6 +54,7 @@ Contents
    setup_guides/index
    deployments
    data
+   catalog
    collaborators
    contact
 


### PR DESCRIPTION
Fixes #301 

Generates a table listing the datasets defined in `gce/catalog.yaml`.

<img width="877" alt="screen shot 2018-09-24 at 10 15 52 am" src="https://user-images.githubusercontent.com/787031/45967426-d7de8a00-bfe2-11e8-9aa9-b514d07a588a.png">
