### PR TITLE
added embedded meeting notes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,6 +55,7 @@ Contents
    deployments
    data
    collaborators
+   meeting-notes
    contact
 
 Examples

--- a/docs/meeting-notes.rst
+++ b/docs/meeting-notes.rst
@@ -1,0 +1,8 @@
+.. _meeting-notes:
+
+Pangeo Weekly Meeting Notes
+===========================
+
+.. raw:: html
+
+    <iframe width="100%" height="800" src="https://docs.google.com/document/d/e/2PACX-1vRerhoxG-wOvh-wQTj7F8HPYve75l8pAtL-tgtzY_3YLqVUsaMSEgE4K70HgMt5S91FMwSu8EIizewy/pub?embedded=true"></iframe>


### PR DESCRIPTION
This PR adds a new page to the website with a simple embed of the weekly meeting notes (see #391). Might be nice to keep this process as open as possible.

What do people think? Appropriate to put out in public or no?