### PR TITLE
update github org members when people.yml is updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,8 @@ script:
   - doctr deploy . --built-docs docs/_build/html
 
 after_script:
-  - python docs/tools/member.py --access_token ${GITHUB_PEOPLE_TOKEN}  --people docs/data/people.yml
+  - if [[ -z "${GITHUB_PEOPLE_TOKEN}" ]]; then
+      echo "skipping because environment variable GITHUB_PEOPLE_TOKEN is not set";
+    else
+      python docs/tools/member.py --access_token ${GITHUB_PEOPLE_TOKEN}  --people docs/data/people.yml;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,6 @@ script:
   - set -e
   - cd docs && make html && cd ..
   - doctr deploy . --built-docs docs/_build/html
+
+after_script:
+  - python docs/tools/member.py --access_token ${GITHUB_PEOPLE_TOKEN}  --people docs/data/people.yml

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,3 +7,6 @@ nbconvert
 nbsphinx
 doctr>=1.6.3
 sphinx-nbexamples
+# for org membership update
+PyGithub
+pyyaml

--- a/docs/tools/member.py
+++ b/docs/tools/member.py
@@ -40,8 +40,6 @@ def main(access_token, people_yml):
 
 if __name__ == "__main__":
 
-    print(list(os.environ.keys()), flush=True)
-
     parser = argparse.ArgumentParser(description='Add users to GitHub Org/Team')
     parser.add_argument('--access_token', required=True, type=str,
                         help='GitHub Access Token')

--- a/docs/tools/member.py
+++ b/docs/tools/member.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import os
 import argparse
 import yaml
 
@@ -38,6 +39,9 @@ def main(access_token, people_yml):
 
 
 if __name__ == "__main__":
+
+    print(list(os.environ.keys()), flush=True)
+
     parser = argparse.ArgumentParser(description='Add users to GitHub Org/Team')
     parser.add_argument('--access_token', required=True, type=str,
                         help='GitHub Access Token')

--- a/docs/tools/member.py
+++ b/docs/tools/member.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+import argparse
+import yaml
+
+from github import Github
+
+
+def main(access_token, people_yml):
+    '''update the Pangeo organization with any new members'''
+    # authentication with GitHub
+    g = Github(access_token)
+    org = g.get_organization('pangeo-data')
+
+    # people.yml is in the pangeo docs
+    with open(people_yml) as f:
+        people = yaml.safe_load(f)
+
+    github_ids = [p['github'] for p in people]
+
+    # pangeo-members = 2180253
+    team = org.get_team(2180253)
+
+    # get existing GitHub members
+    existing_org_logins = list(member.login for member in org.get_members())
+    existing_team_logins = list(member.login for member in team.get_members())
+
+    # add those members not yet in the GitHub org
+    for member in github_ids:
+        user = g.get_user(member)
+        print(user)
+        if member not in existing_org_logins:
+            print(f'--> adding {member} to org')
+            org.add_to_members(user, role='member')
+
+        if member not in existing_team_logins:
+            print(f'--> adding {member} to team')
+            team.add_membership(user, role='member')
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Add users to GitHub Org/Team')
+    parser.add_argument('--access_token', required=True, type=str,
+                        help='GitHub Access Token')
+    parser.add_argument('--people', required=True, type=str,
+                        help='Path to people.yml')
+    args = parser.parse_args()
+    
+    main(args.access_token, args.people)


### PR DESCRIPTION
This is a rough, but working, sketch of how we can keep http://pangeo.io/collaborators.html#people in sync with the `@pangeo-data/pangeo-members` team and the pangeo-data github organization. Both of which can still be managed manually.