### PR TITLE
Simplify setting up a password.

### DIFF
--- a/docs/setup_guides/hpc.rst
+++ b/docs/setup_guides/hpc.rst
@@ -69,6 +69,14 @@ Configure Jupyter
 (If you don't plan to use Jupyter notebooks then you can safely skip
 this section.)
 
+.. note::
+
+   When using recent Jupyter iteration the following section can be replaced by simply invoking the command::
+
+      jupyter notebook password
+
+   And entering desired password.
+
 Jupyter notebook servers include a password for security. We're going to
 setup a password for ourselves. First we generate the Jupyter config
 file


### PR DESCRIPTION
Note that this will store the password in the _json_ config file, likely
`~/.jupyter/jupyter_notebook_config.json` that _takes precedence_ over
the py file (for set options).

The first time you open a jupyter notebook _without passing the token in
the URL_ it also let you set a password from the UI.

-- 
This make setting a password dramatically simpler, but I wasn't sure if old manual way of setting pwd should be removed. 