### PR TITLE
Updated helm chart version

### DIFF
--- a/gce/setup-guide/gce-pangeo-environment.sh
+++ b/gce/setup-guide/gce-pangeo-environment.sh
@@ -17,4 +17,4 @@ export CLUSTER_NAME='pangeo-cluster'
 export WORKER_MACHINE_TYPE='n1-standard-4'
 
 # HELM Pangeo version if needed
-export VERSION="0.1.1-a8f057f"
+export VERSION="0.1.1-c02878a"


### PR DESCRIPTION
the environmental variable used for helm chart now points to "pangeo-v0.1.1-c02878a" released 1/31/19