### PR TITLE
Add 'What is Pangeo' section to index page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,8 +23,8 @@ A community platform for Big Data geoscience
 What is Pangeo?
 ^^^^^^^^^^^^^^^
 
-Pangeo is first and foremost a community promoting open, reproducible science.
-This community provides documentation, develops software, and deploys
+Pangeo is first and foremost a community promoting open, reproducible, and scalable science.
+This community provides documentation, develops and maintains software, and deploys
 computing infrastructure to make scientific research and programming easier.
 Below there are guides for finding and working with publicly available data
 using open source software.  For developers and IT professionals, there are

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,8 @@ What is Pangeo?
 Pangeo is first and foremost a community promoting open, reproducible, and scalable science.
 This community provides documentation, develops and maintains software, and deploys
 computing infrastructure to make scientific research and programming easier.
+Pangeo's community has constructed a software ecosystem that consists of
+existing open source software like numpy, pandas, xarray, and dask.
 Below there are guides for finding and working with publicly available data
 using open source software.  For developers and IT professionals, there are
 instructions for developing cluster or cloud-based infrastructures; making new

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,13 +26,16 @@ What is Pangeo?
 Pangeo is first and foremost a community promoting open, reproducible, and scalable science.
 This community provides documentation, develops and maintains software, and deploys
 computing infrastructure to make scientific research and programming easier.
-Pangeo's community has constructed a software ecosystem that consists of
-existing open source software like numpy, pandas, xarray, and dask.
-Below there are guides for finding and working with publicly available data
-using open source software.  For developers and IT professionals, there are
-instructions for developing cluster or cloud-based infrastructures; making new
-resources available to the community. Pangeo is a work in progress; we welcome
-people just like you to get involved.
+The Pangeo software ecosystem involves
+open source tools such as xarray, iris, dask, jupyter, and many other packages.
+There is no single software package called "pangeo"; rather, the Pangeo project serves
+as a coordination point between scientists, software, and computing infrastructure.
+On this website, scientists can find guides for accessing data and performing analysis
+using these tools. 
+Developers and IT professionals can find
+instructions for deploying cluster or cloud-based infrastructures.
+We welcome you to get more involved by...
+
 
 Our Goals
 ^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,14 +23,14 @@ A community platform for Big Data geoscience
 What is Pangeo?
 ^^^^^^^^^^^^^^^
 
-Pangeo is first and foremost a community promoting open reproducible science.
-This community provides instructions, support, and other resources to make
-scientific research and programming easier. Below there are guides for
-finding and working with publicly available data using open source software.
-For developers and IT professionals, there are instructions for developing
-cluster or cloud-based infrastructures; making new resources available to the
-community. Lastly, the community is happy to answer any remaining
-questions you may have.
+Pangeo is first and foremost a community promoting open, reproducible science.
+This community provides documentation, develops software, and deploys
+computing infrastructure to make scientific research and programming easier.
+Below there are guides for finding and working with publicly available data
+using open source software.  For developers and IT professionals, there are
+instructions for developing cluster or cloud-based infrastructures; making new
+resources available to the community. Pangeo is a work in progress; we welcome
+people just like you to get involved.
 
 Our Goals
 ^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,11 +31,14 @@ open source tools such as xarray, iris, dask, jupyter, and many other packages.
 There is no single software package called "pangeo"; rather, the Pangeo project serves
 as a coordination point between scientists, software, and computing infrastructure.
 On this website, scientists can find guides for accessing data and performing analysis
-using these tools. 
-Developers and IT professionals can find
-instructions for deploying cluster or cloud-based infrastructures.
-We welcome you to get more involved by...
-
+using these tools (read the :ref:`quickstart`, browse the :ref:`use-cases`, and
+learn about the :ref:`packages`).
+Those interested in building infrastructure can find
+instructions for deploying Pangeo environments on HPC or cloud clusters
+(learn about the :ref:`architecture` or read the :ref:`setup-guides`).
+For more general information, read :ref:`about`, see the :ref:`collaborators`,
+or read the :ref:`FAQ`.
+Welcome to the Pangeo community!
 
 Our Goals
 ^^^^^^^^^
@@ -45,16 +48,6 @@ Our Goals
 #. Support the development with domain-specific geoscience packages.
 #. Improve scalability of these tools to handle petabyte-scale datasets on
    HPC and cloud platforms.
-
-Start Here
-^^^^^^^^^^
-
-- **Science users**: read the :ref:`quickstart`, browse the :ref:`use-cases`, or
-  read about the :ref:`packages`.
-- **Developers / system administrators**: learn about the
-  :ref:`architecture` or read the :ref:`setup-guides`.
-- **General interest**: learn :ref:`about`, see the :ref:`collaborators`, or
-  read the :ref:`FAQ`.
 
 Contents
 ^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,18 @@ Pangeo
 A community platform for Big Data geoscience
 ============================================
 
+What is Pangeo?
+^^^^^^^^^^^^^^^
+
+Pangeo is first and foremost a community promoting open reproducible science.
+This community provides instructions, support, and other resources to make
+scientific research and programming easier. Below there are guides for
+finding and working with publicly available data using open source software.
+For developers and IT professionals, there are instructions for developing
+cluster or cloud-based infrastructures; making new resources available to the
+community. Lastly, the community is happy to answer any remaining
+questions you may have.
+
 Our Goals
 ^^^^^^^^^
 


### PR DESCRIPTION
Close #557 

As discussed in #557 this paragraph on the home page is meant to clear up what pangeo is and what people can expect. Since this is on the home page I completely expect everyone to be very critical. Is it too long? Too short? Missing any topic? Redundant? Does having this section mean any other sections should be removed? reduced? combined?

Anything else?