### PR TITLE
Add near-global cloud resolving simulation to catalog

### DIFF
--- a/gce/catalog.yaml
+++ b/gce/catalog.yaml
@@ -218,6 +218,7 @@ sources:
       tags:
         - atmosphere
         - model
+    driver: zarr
     args:
       urlpath: 'gsc://pangeo-data/SAM/NG_5120x2560x34_4km_10s_QOBS_EQX/3d.zarr'
       storage_options:

--- a/gce/catalog.yaml
+++ b/gce/catalog.yaml
@@ -212,3 +212,13 @@ sources:
     args:
       urlpath: 'gs://pangeo-data/hydrosheds/acc.vrt'
       chunks: {'y': 6000, 'x': 6000}
+  sam_ngaqua_qobs_eqx_3d:
+    description: 3D fields from a near-global Aquaplanet Simulation with the System for Atmospheric Modeling
+    metadata:
+      tags:
+        - atmosphere
+        - model
+    args:
+      urlpath: 'gsc://pangeo-data/SAM/NG_5120x2560x34_4km_10s_QOBS_EQX/3d.zarr'
+      storage_options:
+        token: anon


### PR DESCRIPTION
This adds the 3D fields to the pangeo catalog. The surface and top of atmosphere
quantities will be uploaded at a later date.