### PR TITLE
Minor fixes on hpc setup guide for cheyenne

### DIFF
--- a/docs/setup_guides/hpc.rst
+++ b/docs/setup_guides/hpc.rst
@@ -158,11 +158,24 @@ in the Jupyter documentation.
 
 Finally, we may want to configure dask's dashboard to forward through Jupyter.
 This can be done by editing the dask distributed config file, e.g.:
-``.config/dask/distributed.yaml``. In this file, set:
+``.config/dask/distributed.yaml``. By default, when ``dask.distributed`` or
+``dask-jobqueue`` is first imported, it places a file at ``~/.config/dask/distributed.yaml``
+with a commented out version. You can create this file and do this first import by simply 
+
+::
+
+    python -c 'from dask.distributed import Client'
+
+In this ``.config/dask/distributed.yaml`` file, set:
 
 .. code:: python
 
-    diagnostics-link: "/proxy/{port}/status"
+  #   ###################
+  #   # Bokeh dashboard #
+  #   ###################
+  #   dashboard:
+      link: "/proxy/{port}/status"
+      
 
 ------------
 

--- a/docs/setup_guides/hpc.rst
+++ b/docs/setup_guides/hpc.rst
@@ -79,7 +79,8 @@ this section.)
 .. note::
 
    When using recent Jupyter iteration the following section can be replaced by simply invoking the command::
-
+   
+      jupyter notebook --generate-config
       jupyter notebook password
 
    And entering desired password.

--- a/docs/setup_guides/hpc.rst
+++ b/docs/setup_guides/hpc.rst
@@ -34,7 +34,25 @@ After you have logged into your HPC system, download and install Miniconda:
 This contains a self-contained Python environment that we can manipulate
 safely without requiring the involvement of IT. It also allows you to
 create isolated software environments so that we can experiment in the
-future safely.
+future safely. But, we recommend you update your conda package manager 
+before creating your environment with
+
+::
+    
+    conda update conda
+    
+.. note:: 
+
+    Depending if you chose to initialize Miniconda in your ``~/.bashrc``
+    at the end of the installation, this new conda update will activate
+    a ``(base)`` environment by default. If you wish to prevent conda
+    from activating the ``(base)`` environment by default:
+    ::
+    
+            conda config --set auto_activate_base false
+    
+    This will create a ``./condarc`` in your home
+    directory with this setting the first time you run it. 
 
 Create a new conda environment for our pangeo work:
 
@@ -54,7 +72,7 @@ Activate this environment
 
 ::
 
-    source activate pangeo
+    conda activate pangeo
 
 Your prompt should now look something like this (note the pangeo environment name):
 
@@ -171,7 +189,7 @@ In our case, the Cheyenne super computer uses the PBS job scheduler, so typing:
 
 ::
 
-    (pangeo) $ qsub -I -l select=1:ncpus=4 -l walltime=03:00:00 -q regular
+    (pangeo) $ qsub -I -A account -l select=1:ncpus=4 -l walltime=03:00:00 -q regular
 
 This will get us an interactive job on the `regular` queue for three hours. You
 may not see the `pangeo` environment anymore in your prompt, in this case, you
@@ -179,7 +197,7 @@ will want to reactivate it.
 
 ::
 
-    source activate pangeo
+    conda activate pangeo
 
 From here, we can start jupyter. The Cheyenne computer administrators have
 developed a `start-notebook <https://www2.cisl.ucar.edu/resources/computational-systems/cheyenne/software/jupyter-and-ipython#notebook>`__

--- a/docs/setup_guides/hpc.rst
+++ b/docs/setup_guides/hpc.rst
@@ -34,8 +34,8 @@ After you have logged into your HPC system, download and install Miniconda:
 This contains a self-contained Python environment that we can manipulate
 safely without requiring the involvement of IT. It also allows you to
 create isolated software environments so that we can experiment in the
-future safely. But, we recommend you update your conda package manager 
-before creating your environment with
+future safely. Before creating your environment, we recommend you update
+your conda package manager with
 
 ::
     
@@ -46,7 +46,7 @@ before creating your environment with
     Depending if you chose to initialize Miniconda in your ``~/.bashrc``
     at the end of the installation, this new conda update will activate
     a ``(base)`` environment by default. If you wish to prevent conda
-    from activating the ``(base)`` environment by default:
+    from activating the ``(base)`` environment at shell initialization:
     ::
     
             conda config --set auto_activate_base false


### PR DESCRIPTION
updating conda command usage for newer version where ``source activate`` was replaced with ``conda activate`` and added account name for interactive qsub.