### PR TITLE
Update GFDL PPAN deployment description

### DIFF
--- a/docs/data/deployments.yml
+++ b/docs/data/deployments.yml
@@ -194,7 +194,7 @@
 - name: GFDL Post-processing and Analysis Cluster
   description: HPC cluster running at the NOAA Geophyiscal Fluid Dynamics Laboratory
   platform: HPC
-  dask: dask-jobqueue with a custom PBSCluster subclass
+  dask: dask-jobqueue
   jupyter: Single user notebook servers
   kind: hpc
 


### PR DESCRIPTION
This is a bit of an overdue update (my apologies).  I was reminded of this listing in an offline conversation with some GFDL'ers interested in pangeo.

The "custom `PBSCluster` subclass" referred to here has been part of dask-jobqueue for some time now as `MoabCluster`.  More importantly though, GFDL now uses SLURM for job scheduling, so users should make use of dask-jobqueue's `SLURMCluster` instead.