### PR TITLE
Dev website

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ after_script:
   - if [[ "${TRAVIS_BRANCH}" == "master" ]]; then
       doctr deploy . --built-docs docs/_build/html;
     else
-      doctr deploy . --built-docs docs/_build/html --no-require-master --deploy-repo pangeo-data/pangeo-dev-website;
+      doctr deploy dev --built-docs docs/_build/html --branch-whitelist dev;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,16 +24,6 @@ jobs:
     - &build
       stage: build
       install:
-        - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-        - bash miniconda.sh -b -p $HOME/miniconda
-        - export PATH="$HOME/miniconda/bin:$PATH"
-        - hash -r
-        - conda config --set always_yes yes --set changeps1 no
-        - conda update -q conda
-        # Useful for debugging any issues with conda
-        - conda info -a
-        - conda create -q -n docs-environment -c conda-forge python=$TRAVIS_PYTHON_VERSION
-        - source activate docs-environment
         - pip install -r docs/requirements.txt
       script:
         - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,32 +11,16 @@ env:
     - HV_DOC_HTML='true'
     - secure: "YVIIdedqg2auKJNhZTa+GMVMcQE2QJbUhUkCgaMHBI3dQLkX3WLGr148bPUdua7tmxzeScJ6B5oUUJFvJHagYN9nrycFrRZiIv0KnkYBn+rIUnlkUObcgMtKeNu+5/mXUYlkjSxG4Qip0zHgeOsM237Z+BFU1DhDJ7yJ+dQoIWYUSPd6uE4VhSf1lkMj/g2H5tHEB9c4YGdHBpuNHvu+RIyzJbkuLeLm6iM6zuKA7vI16AqzVDs2S4fssZUjYljtqMTBSmOIeavQQ5c209M8hA8wSiALwnD03LVYyZpE2YcsawaREp3+uqEaHui5xTKLogXz79n5+tTkrHEZrCstc+h5+CukyXKoUuhw5j95K4WDUNK9XcXX1TwMf9jMquSJQvnA4mupHFGCvDcenW3oNzOpF7ApyuEHi6+ty2hAZSG3Mr47cGr9I1jobv5tCyuYN/SJTTXuCWOBle72qwhLeSBU47+LpEczvxwIamrTnTkVgK+YJK7lmMzOKQ6l2mPn2EfTDptgAlpIxJuVEFhSRSF3F+wVyt2OFza9Y5cX8vcaKUmA2QT6+4b+w/o40AZHtO3HkZduKsoj8JmHFRppEh3hlVgqp6kTuoXo+DCP2ESTFEBN09Z1pyWlLOi96PojKLR36CeYb08r4OBTZ/yUUeLrP3A3+abA3bkFPSU4+9I="
 
-jobs:
-  include:
-    - &build
-      if: branch != master
-      install:
-        - pip install -r docs/requirements.txt
-      script:
-        - set -e
-        - cd docs
-        # bib file is now stored in the repo
-        #- python build_pangeo_bib.py
-        - make html
-        - cd ..
-
-    - <<: *build
-      if: branch = master
-      after_script: doctr deploy . --built-docs docs/_build/html
-
-    - <<: *build
-      if: (commit_message =~ /^.*(build:dev).*$/)
-      deploy:
-        - provider: pages
-          skip_cleanup: true
-          github_token: $GITHUB_TOKEN
-          local_dir: docs/_build/html
-          repo: pangeo-data/pangeo-dev-website
-          on:
-            tags: true
-            all_branches: true
+install:
+  - pip install -r docs/requirements.txt
+script:
+  - set -e
+  - cd docs
+  - make html
+  - cd ..
+after_script:
+  - if [[ "${TRAVIS_BRANCH}" == "master" ]]; then
+      doctr deploy . --built-docs docs/_build/html;
+    else
+      doctr deploy . --built-docs docs/_build/html --no-require-master --deploy-repo pangeo-data/pangeo-dev-website;
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,18 +11,10 @@ env:
     - HV_DOC_HTML='true'
     - secure: "YVIIdedqg2auKJNhZTa+GMVMcQE2QJbUhUkCgaMHBI3dQLkX3WLGr148bPUdua7tmxzeScJ6B5oUUJFvJHagYN9nrycFrRZiIv0KnkYBn+rIUnlkUObcgMtKeNu+5/mXUYlkjSxG4Qip0zHgeOsM237Z+BFU1DhDJ7yJ+dQoIWYUSPd6uE4VhSf1lkMj/g2H5tHEB9c4YGdHBpuNHvu+RIyzJbkuLeLm6iM6zuKA7vI16AqzVDs2S4fssZUjYljtqMTBSmOIeavQQ5c209M8hA8wSiALwnD03LVYyZpE2YcsawaREp3+uqEaHui5xTKLogXz79n5+tTkrHEZrCstc+h5+CukyXKoUuhw5j95K4WDUNK9XcXX1TwMf9jMquSJQvnA4mupHFGCvDcenW3oNzOpF7ApyuEHi6+ty2hAZSG3Mr47cGr9I1jobv5tCyuYN/SJTTXuCWOBle72qwhLeSBU47+LpEczvxwIamrTnTkVgK+YJK7lmMzOKQ6l2mPn2EfTDptgAlpIxJuVEFhSRSF3F+wVyt2OFza9Y5cX8vcaKUmA2QT6+4b+w/o40AZHtO3HkZduKsoj8JmHFRppEh3hlVgqp6kTuoXo+DCP2ESTFEBN09Z1pyWlLOi96PojKLR36CeYb08r4OBTZ/yUUeLrP3A3+abA3bkFPSU4+9I="
 
-stages:
-  - name: build
-    if: branch != master
-  - name: build_release
-    if: branch = master
-  - name: build_dev
-    if: (commit_message =~ /^.*(build:).*$/) AND (commit_message =~ /^.*(website_dev).*$/)
-
 jobs:
   include:
     - &build
-      stage: build
+      if: branch != master
       install:
         - pip install -r docs/requirements.txt
       script:
@@ -34,17 +26,17 @@ jobs:
         - cd ..
 
     - <<: *build
-      stage: build_release
+      if: branch = master
       after_script: doctr deploy . --built-docs docs/_build/html
 
     - <<: *build
-      stage: build_dev
+      if: (commit_message =~ /^.*(build:dev).*$/)
       deploy:
-        provider: pages
-        skip_cleanup: true
-        github_token: $GITHUB_TOKEN
-        local_dir: docs/_build/html
-        repo: pangeo-data/pangeo-dev-website
-        on:
-          tags: true
-          all_branches: true
+        - provider: pages
+          skip_cleanup: true
+          github_token: $GITHUB_TOKEN
+          local_dir: docs/_build/html
+          repo: pangeo-data/pangeo-dev-website
+          on:
+            tags: true
+            all_branches: true


### PR DESCRIPTION
This ended up different than how I originally imagined, but hopefully it is simpler. 

Some constraints that I hadn't considered:
 1. You can't deploy from a fork (this makes sense if you think about it from a security perspective)
 2. Deploying to another repo is annoying

### What this PR does:
 1. When you push to the `dev` branch, the docs are built as usual, and then the `dev` directory gets added to the gh-pages branch (you should be able to see it there now.
 2. That dir isn't avialable in the nav for the pangeo website but you can access it at this url: https://pangeo.io/dev/

### Some downsides:
 1. I suspect that the dev dir on gh-pages will get over-written whenever someone merges to master. But actually that might be a good thing since we don't want master to get ahead of dev.
 2. The dev branch might get stale.

### How this would be used in practice:
Once a PR has been deemed reasonable, we could merge it to dev as a form of staging, inspect it at https://pangeo.io/dev/ and then if it looks reasonable, merge dev to master and delete the dev branch.