### PR TITLE
Add JASMIN to deployments

### DIFF
--- a/docs/data/deployments.yml
+++ b/docs/data/deployments.yml
@@ -223,10 +223,10 @@
   kind: hpc
   
 - name: JASMIN Cluster-as-a-Service
-  description: Dynamic, user-provisioned Pangeo clusters running on the JASMIN Cloud. Supported by UK Science and Technology Facilities Council.
+  description: Dynamic, user-provisioned Pangeo clusters running on the JASMIN Cloud. UK Natural Environment Research Council (NERC) facility, operated by UK Science and Technology Facilities Council (STFC).
   link: http://www.jasmin.ac.uk/
   platform: OpenStack Cloud
   dask: dask-kubernetes
   jupyter: JupyterHub
-  access: Requires access to a JASMIN Cloud tenancy, available primarily for NCAS-affiliated projects.
+  access: Requires access to a JASMIN Cloud tenancy, available primarily for NERC-affiliated projects.
   kind: openstack

--- a/docs/data/deployments.yml
+++ b/docs/data/deployments.yml
@@ -221,3 +221,11 @@
   dask: dask-jobqueue
   jupyter: Single user notebook servers
   kind: hpc
+  
+- name: JASMIN Super-Data-Cluster
+  description: UK Science and Technology Facilities Council
+  link: http://www.jasmin.ac.uk/
+  platform: HPC
+  dask: ???
+  jupyter: Single user notebook servers
+  kind: hpc

--- a/docs/data/deployments.yml
+++ b/docs/data/deployments.yml
@@ -228,5 +228,5 @@
   platform: OpenStack Cloud
   dask: dask-kubernetes
   jupyter: JupyterHub
-  kind: openstack
   access: Requires access to a JASMIN Cloud tenancy, available primarily for NCAS-affiliated projects.
+  kind: openstack

--- a/docs/data/deployments.yml
+++ b/docs/data/deployments.yml
@@ -222,10 +222,10 @@
   jupyter: Single user notebook servers
   kind: hpc
   
-- name: JASMIN Super-Data-Cluster
-  description: UK Science and Technology Facilities Council
+- name: JASMIN Cluster-as-a-Service
+  description: Dynamic, user-provisioned Pangeo clusters running on the JASMIN Cloud. Supported by UK Science and Technology Facilities Council.
   link: http://www.jasmin.ac.uk/
-  platform: HPC
-  dask: ???
-  jupyter: Single user notebook servers
-  kind: hpc
+  platform: OpenStack Cloud
+  dask: dask-kubernetes
+  jupyter: JupyterHub
+  kind: openstack

--- a/docs/data/deployments.yml
+++ b/docs/data/deployments.yml
@@ -229,3 +229,4 @@
   dask: dask-kubernetes
   jupyter: JupyterHub
   kind: openstack
+  access: Requires access to a JASMIN Cloud tenancy, available primarily for NCAS-affiliated projects.


### PR DESCRIPTION
Requested by @mkjpryor-stfc
JASMIN now supports deployments of Pangeo.

@mkjpryor-stfc: Could you please review this? I was unsure on
- Exact name you wanted
- Exact description
- What implementation of dask you have on JASMIN