### PR TITLE
Replace pangeo.pydata.org with hub.pangeo.io

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -90,7 +90,7 @@ Cloud
 Commercial Cloud Computing offers the scientific community a fundamentally new
 model for doing data science. A specific focus of Pangeo is the development of
 scalable, flexible, and configurable cloud deployments. Our flagship deployment
-is `pangeo.pydata.org <http://pangeo.pydata.org>`__ running on Google Cloud
+is `hub.pangeo.io <https://hub.pangeo.io>`__ running on Google Cloud
 Platform.
 
 Storage Formats

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -216,10 +216,10 @@ These recommendations may change as cloud storage technology evolves.
    charges for data transfers.
    The ``pangeo-data`` bucket is in Google Cloud Storage in the ``US-CENTRAL1``
    region. It can therefore be accessed by the flagship
-   `pangeo.pydata.org <http://pangeo.pydata.org>`_ deployment.
+   `hub.pangeo.io <https://hub.pangeo.io>`_ deployment.
 
    To open the dataset we just uploaded from within a notebook or script in
-   pangeo.pydata.org, do the following:
+   hub.pangeo.io, do the following:
 
    .. code-block:: python
 

--- a/docs/data/deployments.yml
+++ b/docs/data/deployments.yml
@@ -44,15 +44,6 @@
   access: Used by Pangeo core developers, need a github account and specific authorization
   kind: pangeo_cloud
 
-- name: pangeo.pydata.org
-  description: Former flagship Pangeo JupyterHub server for scalable interactive data analysis running on Google Cloud Platform
-  link: http://pangeo.pydata.org
-  platform: Google Cloud Platform
-  dask: dask-kubernetes
-  jupyter: JupyterHub
-  access: Soon being closed
-  kind: pangeo_cloud
-
 - name: binder.pangeo.io
   description: Flagship Pangeo BinderHub deployment running on Google Cloud Platform
   link: http://binder.pangeo.io/

--- a/docs/setup_guides/cloud.rst
+++ b/docs/setup_guides/cloud.rst
@@ -199,7 +199,7 @@ command
 
    kubectl --namespace=pangeo get svc proxy-public
 
-Here's what we see for pangeo.pydata.org when we run this commmand::
+Here's what we see for hub.pangeo.io when we run this commmand::
 
   NAME           TYPE           CLUSTER-IP      EXTERNAL-IP    PORT(S)        AGE
   proxy-public   LoadBalancer   10.23.255.193   35.224.8.169   80:30442/TCP   18d


### PR DESCRIPTION
This PR changes references to `pangeo.pydata.org` (which has been closed) to `hub.pangeo.io`