### PR TITLE
Add Sphinx preview workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Test Sphinx site
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ 'better-pr-workflow' ]
     paths: [ 'docs/**' ]
 
 jobs:
@@ -17,3 +17,21 @@ jobs:
       uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"
+        
+    - name: Commit documentation changes to preview branch
+      run: |
+        git clone https://github.com/pangeo-data/pangeo.git --branch gh-pages --single-branch gh-pages
+        cd gh-pages
+        git checkout -b $GITHUB_REF-preview
+        cp -r ../docs/_build/html/* .
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add .
+        git commit -m "Create preview documentation" -a || true
+        
+    - name: Push documentation changes to preview branch
+      uses: ad-m/github-push-action@master
+      with:
+        branch: ${{ github.head_ref }}-preview
+        directory: gh-pages
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,14 +18,20 @@ jobs:
       with:
         docs-folder: "docs/"
         
+    - name: Create new preview branch
+      uses: peterjgrainger/action-create-branch@v2.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        branch: ${{ github.head_ref }}-preview
+        
     - name: Commit documentation changes to preview branch
       run: |
-        git clone https://github.com/pangeo-data/pangeo.git --branch gh-pages --single-branch gh-pages
-        cd gh-pages
-        git checkout -B $GITHUB_REF-preview
-        cp -r ../docs/_build/html/* .
+        git clone https://github.com/pangeo-data/pangeo.git --branch $GITHUB_REF-preview --single-branch gh-pages
+        cp -r docs/_build/html/* gh-pages/
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
+        cd gh-pages
         git add .
         git commit -m "Create preview documentation" -a || true
         

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         git clone https://github.com/pangeo-data/pangeo.git --branch gh-pages --single-branch gh-pages
         cd gh-pages
-        git checkout -b $GITHUB_REF-preview
+        git checkout -B $GITHUB_REF-preview
         cp -r ../docs/_build/html/* .
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Build Sphinx site
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths: [ 'docs/**' ]
+
+jobs:
+  build:
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Build Sphinx documentation
+      uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "docs/"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,26 +18,39 @@ jobs:
       with:
         docs-folder: "docs/"
         
-    - name: Create new preview branch
-      uses: peterjgrainger/action-create-branch@v2.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        branch: ${{ github.head_ref }}-preview
-        
     - name: Commit documentation changes to preview branch
       run: |
-        git clone https://github.com/pangeo-data/pangeo.git --branch $GITHUB_REF-preview --single-branch gh-pages
-        cp -r docs/_build/html/* gh-pages/
+        if git clone https://github.com/pangeo-data/pangeo.git --branch ${{ github.head_ref }}-preview --single-branch gh-pages ; then
+          cd gh-pages
+          echo "COMMENT_ON_PR=false" >> $GITHUB_ENV
+        else
+          git clone https://github.com/pangeo-data/pangeo.git --branch gh-pages --single-branch gh-pages
+          cd gh-pages
+          git checkout -b ${{ github.head_ref }}-preview
+          echo "COMMENT_ON_PR=true" >> $GITHUB_ENV
+        fi
+        cp -r ../docs/_build/html/* .
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-        cd gh-pages
         git add .
-        git commit -m "Create preview documentation" -a || true
-        
+        git commit -m "Update documentation" -a || true
+ 
     - name: Push documentation changes to preview branch
       uses: ad-m/github-push-action@master
       with:
         branch: ${{ github.head_ref }}-preview
         directory: gh-pages
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Leave comment on pull request
+      if: env.COMMENT_ON_PR == 'true'
+      uses: actions/github-script@v3
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'Thank you for your contributions!\n\nA preview of your changes can be viewed at:\n- https://raw.githack.com/pangeo-data/pangeo/${{ github.head_ref }}-preview/index.html'
+            })

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,8 +1,8 @@
-name: Test Sphinx site
+name: Build and preview Sphinx site
 
 on:
   pull_request:
-    branches: [ 'better-pr-workflow' ]
+    branches: [ master ]
     paths: [ 'docs/**' ]
 
 jobs:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,8 +7,8 @@ on:
 
 jobs:
   build:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -2,7 +2,7 @@ name: Build and preview Sphinx site
 
 on:
   pull_request:
-    branches: [ 'better-pr-workflow' ]
+    branches: [ master ]
     paths: [ 'docs/**' ]
 
 jobs:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -2,7 +2,7 @@ name: Build and preview Sphinx site
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ 'better-pr-workflow' ]
     paths: [ 'docs/**' ]
 
 jobs:


### PR DESCRIPTION
This updates the workflow executed when a local PR is opened to make changes to the website. Now, when a PR is made to change the website, this workflow will:

- Build the Sphinx site using the head branch's source code
- Push the build to a branch of `gh-pages` called `[head_branch]-preview`, creating the branch if it doesn't already exist
- Leave a comment on the PR with a link to the preview website, served using [Raw GitHack](https://raw.githack.com/) (this will only happen once when the preview branch is created, and will be skipped on subsequent updates)

This should be useful for if a user wants to make changes to elements of the website with precise formatting, but doesn't have the ability to do so on their local machine.

Some minor things to note:

- This will only work on PRs from branches within this repo - if a PR is made from a forked branch, only the standard build tests will be done.
- Unexpected behavior will occur if the `-preview` branch is already in use for something else; this doesn't seem likely as it would require the existence of both `[head_branch]` AND `[head_branch]-preview`, but if it becomes an issue the naming convention can be easily changed in the future.