### PR TITLE
Add Project Pythia content to the Meetings page

### DIFF
--- a/docs/meeting-notes.rst
+++ b/docs/meeting-notes.rst
@@ -7,7 +7,7 @@ Weekly Community Meeting
 ------------------------
 
 Pangeo holds weekly check-in meetings every Wednesday. The meetings are held on
-`Zoom <https://columbiauniversity.zoom.us/j/953527251>`_. These meetings are open to 
+`Zoom <https://columbiauniversity.zoom.us/j/953527251>`_. These meetings are open to
 anyone who wishes to participate. The meeting alternates between an early and
 late time to allow participants from multiple time zones to attend. We publish
 the `meeting notes here <https://docs.google.com/document/d/e/2PACX-1vRerhoxG-wOvh-wQTj7F8HPYve75l8pAtL-tgtzY_3YLqVUsaMSEgE4K70HgMt5S91FMwSu8EIizewy/pub>`_.
@@ -36,8 +36,7 @@ Working Group Meetings
 4. `Project Pythia <https://projectpythia.org>`_ (formerly the Education Working Group)
     * Schedule: Thursdays at 1p US Eastern Time (alternating between Project Pythia Education and Infrastructure Working Groups)
     * Conferencing: `Zoom <https://ucar-edu.zoom.us/j/91375487587>`_ (consult the `Pythia Calendar <https://calendar.google.com/calendar/u/0?cid=Y180cXB2ZjMxNmFmZDltdjBjaTdkMnVpYWZvZ0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t>`_ for how to join)
-    * Infrastructure Working Group Notes: `link <https://docs.google.com/document/d/e/2PACX-1vQN5YFkZtCZPKVk2Rte2xoHuiqJuYz1KpynsSKmeCLwP-4glUsGuCPJbITwB4OJc8dOhUpHAMacdx59/pub>`__
-    * Education Working Group Notes: `link <https://docs.google.com/document/d/e/2PACX-1vTHJKdeWfQBbkrGt8RsSVKJHy5uAQumD40_hRXhRKDGpLO-4ACBlMdQNyR-ap-Q19Zwdq2m5yUk_mZk/pub>`__
+    * Notes: `link <https://docs.google.com/document/d/e/2PACX-1vQN5YFkZtCZPKVk2Rte2xoHuiqJuYz1KpynsSKmeCLwP-4glUsGuCPJbITwB4OJc8dOhUpHAMacdx59/pub>`__
 
 Meeting Calendar
 ----------------

--- a/docs/meeting-notes.rst
+++ b/docs/meeting-notes.rst
@@ -29,19 +29,20 @@ Working Group Meetings
     * Schedule: First Monday of the month at 4p GMT
     * Conferencing:  `Google Hangouts <https://meet.google.com/ubc-tgak-ugg>`_
     * Notes: `link <https://paper.dropbox.com/doc/Meeting-notes-Machine-Learning-WG--AmU~wZXwdbpTZi8rQsJQH9_sAg-9UUgyywF9jmIMXXbmZTyJ>`__
-3. Education Working Group 
-    * Schedule: (Schedule TBD)
-    * Conferencing: `whereby.com/pangeo <https://whereby.com/pangeo>`_
-    * Notes: `GitHub <https://github.com/pangeo-data/education-material>`__
-4. Cloud Operations Working Group
+3. Cloud Operations Working Group
     * Schedule: Second Monday of the month at 4:30p GMT
     * Conferencing: `whereby.com/pangeo <https://whereby.com/pangeo>`_
     * Notes: `link <https://docs.google.com/document/d/1I-2VNNHoAjjeYvlCezQhFLmiu2OevqGDS5nUAP-6Hfw/edit?usp=sharing>`__
-    
+4. `Project Pythia <https://projectpythia.org>`_ (formerly the Education Working Group)
+    * Schedule: Thursdays at 1p US Eastern Time (alternating between Project Pythia Education and Infrastructure Working Groups)
+    * Conferencing: `Zoom <https://ucar-edu.zoom.us/j/91375487587>`_ (consult the `Pythia Calendar <https://calendar.google.com/calendar/u/0?cid=Y180cXB2ZjMxNmFmZDltdjBjaTdkMnVpYWZvZ0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t>`_ for how to join)
+    * Infrastructure Working Group Notes: `link <https://docs.google.com/document/d/e/2PACX-1vQN5YFkZtCZPKVk2Rte2xoHuiqJuYz1KpynsSKmeCLwP-4glUsGuCPJbITwB4OJc8dOhUpHAMacdx59/pub>`__
+    * Education Working Group Notes: `link <https://docs.google.com/document/d/e/2PACX-1vTHJKdeWfQBbkrGt8RsSVKJHy5uAQumD40_hRXhRKDGpLO-4ACBlMdQNyR-ap-Q19Zwdq2m5yUk_mZk/pub>`__
+
 Meeting Calendar
 ----------------
 
-A google calendar has been setup with these reoccurring times [GCAL_, ICAL_].
+A Google Calendar has been setup with these reoccurring times [GCAL_, ICAL_].
 
 .. _GCAL: https://calendar.google.com/calendar/embed?src=ucar.edu_c23ln4014khs3f65o93vqv5kqc%40group.calendar.google.com&ctz=America%2FLos_Angeles
 .. _ICAL: https://calendar.google.com/calendar/ical/ucar.edu_c23ln4014khs3f65o93vqv5kqc%40group.calendar.google.com/public/basic.ics


### PR DESCRIPTION
I've added a first draft of content for the Pangeo Meetings page regarding Project Pythia meetings.  I'm not sure this is how we want to present it, but it seems the most reasonable.