### PR TITLE
Added link to new weekly talks page

### DIFF
--- a/docs/meeting-notes.rst
+++ b/docs/meeting-notes.rst
@@ -9,7 +9,11 @@ Weekly Community Meeting
 Pangeo holds weekly check-in meetings every Wednesday. The meetings are held on
 `Zoom <https://columbiauniversity.zoom.us/j/953527251>`_. These meetings are open to 
 anyone who wishes to participate. The meeting alternates between an early and
-late time to allow participants from multiple time zones to attend. We publish
+late time to allow participants from multiple time zones to attend.
+
+See the  `Full list of recorded and upcoming talks here <https://docs.google.com/document/d/1ekBiaAdACBjI3lel9QnV389zveADh8BDEIcYILCUybc/edit?usp=sharing>`_.
+
+We publish
 the `meeting notes here <https://docs.google.com/document/d/e/2PACX-1vRerhoxG-wOvh-wQTj7F8HPYve75l8pAtL-tgtzY_3YLqVUsaMSEgE4K70HgMt5S91FMwSu8EIizewy/pub>`_.
 
 **Schedule**


### PR DESCRIPTION
Link to new google doc that lists recorded and upcoming talks for the [new weekly meeting format](https://discourse.pangeo.io/t/new-weekly-meeting-format-logistics/1156)

@clyne, we need to populate the [google doc with planned talks](https://docs.google.com/document/d/1ekBiaAdACBjI3lel9QnV389zveADh8BDEIcYILCUybc/edit?usp=sharing) acquired from the [google form](https://forms.gle/QwxKusVvrvDakSNs8). 