### PR TITLE
Update copy button to ignore Python/bash/Jupyter prompts

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,8 @@ extensions = [
     'sphinxcontrib.bibtex',
     'sphinxcontrib.srclinks']
 
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
This PR updates the `sphinx-copybutton` extension to [ignore prompts like `$ `, `>>> `, `... `, `In [999]: `](https://sphinx-copybutton.readthedocs.io/en/latest/#using-regexp-prompt-identifiers).

This means that when someone uses the copy button on a code block that looks like:

```python
>>> from dask_gateway import GatewayCluster
>>> cluster = GatewayCluster()  # create the cluster nomrally
>>> client = cluster.get_client()
>>> # Now create and register the plugin. We'll install 'bulwark'
>>> plugin = PipPlugin(['bulwark'])
>>> client.register_worker_plugin(plugin)
```

the `>>> ` portion will be ignored and 

```python
from dask_gateway import GatewayCluster
cluster = GatewayCluster()  # create the cluster nomrally
client = cluster.get_client()
# Now create and register the plugin. We'll install 'bulwark'
plugin = PipPlugin(['bulwark'])
client.register_worker_plugin(plugin)
```

will be copied to the user's clipboard. This is convenient when copy / pasting code from the docs. 