### PR TITLE
Fix link to software environment section

### DIFF
--- a/docs/cloud.rst
+++ b/docs/cloud.rst
@@ -143,7 +143,7 @@ the image used for JupyterHub. It won't, however, have changes you've made
 in your "local" environment in your home directory on the hub.
 
 Long-term, the best way to add packages to the environemnt is by updating the
-Docker images, as described in :ref:`cloud.software_environment`_. But for quickly
+Docker images, as described in :ref:`cloud.software_environment`. But for quickly
 prototyping something on the Dask cluster you can use a
 `Dask WorkerPlugin <https://distributed.dask.org/en/latest/plugins.html#distributed.diagnostics.plugin.WorkerPlugin>`_.
 This lets you inject a bit of code that's run when the worker starts up. This


### PR DESCRIPTION
This PR removes an extra trailing underscore which causes this link to not be rendered correctly (see screenshot below)

<img width="295" alt="Screen Shot 2021-03-12 at 9 22 05 PM" src="https://user-images.githubusercontent.com/11656932/111017428-1dd96500-8379-11eb-8b87-38721ff6861d.png">
