### PR TITLE
Fixed xarray logo link

### DIFF
--- a/docs/packages.rst
+++ b/docs/packages.rst
@@ -25,7 +25,7 @@ packages are considered essential to the project.
 Xarray
 ~~~~~~
 
-.. image:: https://github.com/pydata/xarray/raw/master/doc/_static/dataset-diagram-logo.png
+.. image:: https://github.com/pydata/xarray/raw/main/doc/_static/dataset-diagram-logo.png
    :width: 300 px
 
 - Website: http://xarray.pydata.org/en/latest


### PR DESCRIPTION
xarray's logo wasn't showing on the pangeo website because they recently changed their main branch from master to main.