### PR TITLE
Update ML working group video conference link

### DIFF
--- a/docs/meeting-notes.rst
+++ b/docs/meeting-notes.rst
@@ -25,7 +25,7 @@ Working Group Meetings
 
 1. Machine Learning Working Group
     * Schedule: First Monday of the month at 12p ET
-    * Conferencing:  `Google Hangouts <https://meet.google.com/ubc-tgak-ugg>`_
+    * Conferencing: `Zoom <https://us02web.zoom.us/j/89838681369?pwd=MWJWSWVqMU5pVklZZU9oWWxlRGZZZz09>`
     * Notes: `Dropbox doc <https://paper.dropbox.com/doc/Meeting-notes-Machine-Learning-WG--AmU~wZXwdbpTZi8rQsJQH9_sAg-9UUgyywF9jmIMXXbmZTyJ>`__
 2. Cloud Operations Working Group
     * Schedule: Second Monday of the month at 11:30a ET


### PR DESCRIPTION
Replaced google meet link with zoom to address issues with NCAR host needing to be on the call to let people in.