### PR TITLE
Update European coffee link

### DIFF
--- a/docs/meeting-notes.rst
+++ b/docs/meeting-notes.rst
@@ -31,7 +31,7 @@ To adress different time zones among the globe continental meetings have been or
 
    - Cofee table; an uninformal meeting with open discussions:   
       * Schedule: Every week on Tusday at 10a CET
-      * Conferencing: `Zoom <https://cnrs.zoom.us/j/95432814658>`_  password: Pangeo2EU
+      * Conferencing: Conferencing: `whereby.com/pangeo-europe <https://whereby.com/pangeo-europe>`_
       * Notes: `Google Doc <https://docs.google.com/document/d/1Vq1ljPRQYWF_u0Ku1eEhQyYreijAJ2QW6FELdIsiYDs/edit?usp=sharing>`__
    - Monthly meeting: 
       * Schedule: (to be scheduled)  


### PR DESCRIPTION
Co-organisator can't be easily added with institutional zoom link, which is not convenient for a coffee.  We've created new coffee place, which does not need a fixed person to start a conference. From next Tuesday (10:00CET) we will host pangeo european coffee at https://whereby.com/pangeo-europe 