### PR TITLE
Update copyright year to 2018-2021

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Pangeo'
-copyright = '2018-2020, Pangeo Team'
+copyright = '2018-2021, Pangeo Team'
 author = 'Pangeo Team'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
This pull requests updates the copyright year on the Pangeo docs to be 2018-2021.