### PR TITLE
Minor updates to the speaker links

### DIFF
--- a/docs/pangeo-showcase.rst
+++ b/docs/pangeo-showcase.rst
@@ -28,33 +28,33 @@ Fall 2022 Showcase
      - Title
    * - 2022-09-21 12PM EDT
      - Peter Marsh
-     - `Accessing NetCDF and GRIB file collections as cloud-native virtual datasets using Kerchunk <https://discourse.pangeo.io/>`_ 
+     - `Accessing NetCDF and GRIB file collections as cloud-native virtual datasets using Kerchunk <https://discourse.pangeo.io/t/september-21th-2022-accessing-netcdf-and-grib-file-collections-as-cloud-native-virtual-datasets-using-kerchunk/2749>`_ 
    * - 2022-09-28 4PM EDT
      - Rich Signell
-     - `My ERA5 Journey: From API-to-ARCO <https://discourse.pangeo.io/>`_      
+     - `My ERA5 Journey: From API-to-ARCO <https://discourse.pangeo.io/c/meta/pangeo-showcase/19>`_      
    * - 2022-10-05 12PM EDT
      - Leah Wasser
-     - `PyOpenSci <https://discourse.pangeo.io/>`_      
+     - `PyOpenSci <https://discourse.pangeo.io/c/meta/pangeo-showcase/19>`_      
    * - 2022-10-12 4PM EDT
      - TBD
-     - `TBD <https://discourse.pangeo.io/>`_ 
+     - `TBD <https://discourse.pangeo.io/c/meta/pangeo-showcase/19>`_ 
    * - 2022-10-19 12PM EDT
      - Matthias Mohr
-     - `openEO: What it is and how it relates to Pangeo <https://discourse.pangeo.io/>`_      
+     - `openEO: What it is and how it relates to Pangeo <https://discourse.pangeo.io/c/meta/pangeo-showcase/19>`_      
    * - 2022-10-26 4PM EDT
      - Hauke Schulz
-     - `Xbitinfo: Compress datasets based on their information content <https://discourse.pangeo.io/>`_      
+     - `Xbitinfo: Compress datasets based on their information content <https://discourse.pangeo.io/c/meta/pangeo-showcase/19>`_      
    * - 2022-11-02 12PM EDT
      - TBD
-     - `TBD <https://discourse.pangeo.io/>`_    
+     - `TBD <https://discourse.pangeo.io/c/meta/pangeo-showcase/19>`_    
    * - 2022-11-09 4PM EST
      - TBD
-     - `TBD <https://discourse.pangeo.io/>`_ 
+     - `TBD <https://discourse.pangeo.io/c/meta/pangeo-showcase/19>`_ 
    * - 2022-11-16 12PM EST
      - TBD
-     - `TBD <https://discourse.pangeo.io/>`_ 
+     - `TBD <https://discourse.pangeo.io/c/meta/pangeo-showcase/19>`_ 
 
-Please note that the Pangeo Showcase will go on Winter Break after the talk on Nov. 17th. We will resume Showcase presentations in January 2023. If you are intersted in presenting, please makes sure to `fill out this short form <https://forms.gle/QwxKusVvrvDakSNs8>`_.
+Please note that the Pangeo Showcase will go on Winter Break after the talk on Nov. 17th. We will resume Showcase presentations in January 2023. If you are intersted in presenting, please make sure to `fill out this short form <https://forms.gle/QwxKusVvrvDakSNs8>`_.
 
 Showcase Archive
 -----------------------------------


### PR DESCRIPTION
Currently, the links for each speaker's content all point to the main Discourse site, which seems like a broken link. I have made the following changes in this PR:

- Added a link directly to Peter Marsh's talk description on Discourse
- Changed the default link to point to the Pangeo Showcase category on Discourse instead of the main Discourse site (an alternative would be removing the links entirely until there is information posted about that specific talk)
- Fixed a very minor typo