### PR TITLE
Add link for COSIMA showcase and removed link for GDN

### DIFF
--- a/docs/pangeo-showcase.rst
+++ b/docs/pangeo-showcase.rst
@@ -64,10 +64,10 @@ Spring 2023 Showcase
      - *Open time slots!*
    * - 2023-05-10 4PM EDT
      - Navid Constantinou, Australian National University
-     - `Open-source and reproducibility workflow within the Consortium for Ocean-Sea Ice Modelling in Australia (COSIMA) <https://pangeo.io/pangeo-showcase.html>`_ 
+     - `Open-source and reproducibility workflow within the Consortium for Ocean-Sea Ice Modelling in Australia (COSIMA) <https://discourse.pangeo.io/t/open-source-and-reproducibility-workflow-within-the-consortium-for-ocean-sea-ice-modelling-in-australia-cosima/3405>`_ 
    * - 2023-05-17 12PM EDT
      - Campbell Watson, IBM
-     - `The Geospatial Discovery Network: Accelerating geospatial science in the multicloud future <https://pangeo.io/pangeo-showcase.html>`_ 
+     - The Geospatial Discovery Network: Accelerating geospatial science in the multicloud future 
    
 
 **We still have slots available from March 15 through June** - if you are intersted in presenting, please `fill out this short form <https://forms.gle/QwxKusVvrvDakSNs8>`_.


### PR DESCRIPTION
Removed link for the geospatial discovery network, since I don't see a discourse page for that and I find linking to the showcase page confusing (feels like a broken link)