### PR TITLE
Add links to governance docs

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -65,4 +65,8 @@ There are many ways to get involved:
 - *Developers / system administrators*: learn about the
   :ref:`architecture` or read the :ref:`setup-guides`.
 
+Governance
+------------
+For information about the governance of the Pangeo community, view our :ref:`governance repository <https://github.com/pangeo-data/governance>`, which includes our :ref:`governance document <https://github.com/pangeo-data/governance/blob/master/governance.md>` and :ref:`list of Steering Council membership <https://github.com/pangeo-data/governance/blob/master/steering_council_membership.md>`.
+
 For more information, consult the :ref:`FAQ`.

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -67,6 +67,6 @@ There are many ways to get involved:
 
 Governance
 ------------
-For information about the governance of the Pangeo community, view our :ref:`governance repository <https://github.com/pangeo-data/governance>`, which includes our :ref:`governance document <https://github.com/pangeo-data/governance/blob/master/governance.md>` and :ref:`list of Steering Council membership <https://github.com/pangeo-data/governance/blob/master/steering_council_membership.md>`.
+For information about the governance of the Pangeo community, view our `governance repository <https://github.com/pangeo-data/governance>`_, which includes our `governance document <https://github.com/pangeo-data/governance/blob/master/governance.md>`_ and `list of Steering Council members <https://github.com/pangeo-data/governance/blob/master/steering_council_membership.md>`_.
 
 For more information, consult the :ref:`FAQ`.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
+sphinx>=3.5
 sphinx_pangeo_theme
 sphinx-copybutton
 sphinxcontrib-srclinks
-# we need to eventually upgrade sphinx in order to unpin
+
 sphinxcontrib-bibtex
 myst_parser


### PR DESCRIPTION
Add links on the About page to our governance docs.